### PR TITLE
added support for "fromNow" display syntax

### DIFF
--- a/backgrid-moment-cell.js
+++ b/backgrid-moment-cell.js
@@ -96,6 +96,7 @@
     fromRaw: function (rawData) {
       if (rawData == null) return '';
 
+      var result;
       var m = this.modelInUnixOffset ? moment(rawData) :
         this.modelInUnixTimestamp ? moment.unix(rawData) :
         this.modelInUTC ?
@@ -109,8 +110,14 @@
       if (this.displayLang) m.lang(this.displayLang);
 
       if (this.displayInUTC) m.utc(); else m.local();
+      
+      if (this.displayFormat === 'fromNow') {
+        result = m.fromNow();
+      } else {
+        result = m.format(this.displayFormat);
+      }
 
-      return m.format(this.displayFormat);
+      return result;
     },
 
     /**


### PR DESCRIPTION
if displayFormat is set to "fromNow", the cell will use moment.fromNow() to format the model